### PR TITLE
Fixes error when setLevel called by windowShade

### DIFF
--- a/fibaro_fgr_222/fibaro_fgr_222.groovy
+++ b/fibaro_fgr_222/fibaro_fgr_222.groovy
@@ -292,7 +292,13 @@ def refresh() {
 ], 500)
 }
 
-def setLevel(level) {
+def setLevel(requestedLevel) {
+    if (!requestedLevel?.isInteger()) {
+    	debug.log ("Cannot convert ${requestedLevel} to int")
+        return
+    }
+    int level = requestedLevel as int
+
     if (invert) {
         level = 100 - level
     }


### PR DESCRIPTION
Using the "Open or Close Window Shades" option in Routines was not working.  Debug log showed an error along the lines of 
```
groovy.lang.MissingMethodException:` No signature of method: java.lang.Integer.minus() is applicable for argument types: (java.lang.String)
```
So whilst I don't understand where the string is coming from, we can at least make sure that it gets cast to an int :-)

Hopefully should fix issues such as reported here:

https://community.smartthings.com/t/fibaro-roller-shutter-2-fgrm-222-dth-in-post-24-uk-device/65005/75

